### PR TITLE
Add optional BASE_OID show-tested-oids options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,17 +9,18 @@ It works by parsing the output of 'snmpwalk', followed by determining all elemen
 Net-SNMP tools `snmpwalk`, `snmpset` and `snmpget`
 
 # Usage
-`snmp-write-check.py [OPTIONS] AGENT [PARAMETERS]`
+`snmp-write-check.py [OPTIONS] AGENT [BASE_OID] [PARAMETERS] --show-tested-oids`
 where 
 * `[OPTIONS]` includes info like version `-v`, community string `-c` or credentials for v3
 * `AGENT` represents the IP address or hostname of device
+* `[BASE_OID]` is the optional OID to start the walk from
+* `--show-tested-oids` is a flag to show the list of tested OIDs (writeable or not)
 
 these will be passed directly to `snmpwalk`, `snmpset` and `snmpget`
 
-**DISCLAIMAR** The script might change the value of the writable OID or cause other effects. Use with care.
+**DISCLAIMER** The script might change the value of the writable OID or cause other effects. Use with care.
 
-
-# SNMP Security Recommandations
+# SNMP Security Recommendations
 
 1. Disable SNMP v1 and v2c
 Both of this versions are communicationg in plain-text.

--- a/snmp-write-check.py
+++ b/snmp-write-check.py
@@ -2,32 +2,36 @@
 
 import sys
 import re
-
 import shlex
 import subprocess
 from subprocess import PIPE
 
-#Debug flag
+# Debug flag
 debug = False
+show_tested_oids = False
 
-#Display help 
-if len(sys.argv)==1 or sys.argv[1].lower()=="-h" or sys.argv[1].lower()=="--help":
-    usage={}
-    usage["desc"] = """Returns the number of writable OIDs and list them.
+# Display help 
+if len(sys.argv) == 1 or sys.argv[1].lower() == "-h" or sys.argv[1].lower() == "--help":
+    usage = {}
+    usage["desc"] = """Returns the number of writable OIDs and lists them.
 Parses the output of 'snmpwalk' and determines all elements that are readable. The return code of 'snmpset' is used to determine if an element's value can be written, by performing a write with the exact actual value.
 """
-    usage["cmd"] = f"Syntax:\t{sys.argv[0]} [OPTIONS] AGENT [PARAMETERS] #see man snmpcmd"
-    usage["example"] = f"Example: {sys.argv[0]} -v 2c -c public 192.168.0.3"
+    usage["cmd"] = f"Syntax:\t{sys.argv[0]} [OPTIONS] AGENT [BASE_OID] [--show-tested-oids] #see man snmpcmd"
+    usage["example"] = f"Example: {sys.argv[0]} -v 2c -c public 192.168.0.3 .1.3.6.1.2.1 --show-tested-oids"
     usage["disclaimer"] = """
 DISCLAIMAR: The script might change the value of the writable or cause other effects. Use with care.
-""" 
+"""
     print("\n".join(usage.values()))
     sys.exit(0)
 
-#Simply the command line options to snmpwalk and snmpset
-options_agent = ' '.join(sys.argv[1:])
+# Parse the command line arguments
+options_agent = ' '.join(arg for arg in sys.argv[1:] if not arg.startswith('--'))
+show_tested_oids = '--show-tested-oids' in sys.argv
 
-cmd = f"snmpwalk {options_agent}"
+# Optional base OID
+base_oid = sys.argv[-1] if sys.argv[-1].startswith('.') else ''
+
+cmd = f"snmpwalk -ObentU {options_agent} {base_oid}"
 args = shlex.split(cmd)
 proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 out = proc.stdout.read().decode()
@@ -35,33 +39,42 @@ out = proc.stdout.read().decode()
 if(debug):
     print(f"{cmd}\n{out}\n\n")
 
-#map between snmpwalk output and expected type by snmpset
-type_map = {"INTEGER":'i', "unsigned INTEGER":'u', "UNSIGNED":'u', "TIMETICKS":'t', "Timeticks":'t', "IPADDRESS":'a', "OBJID":'o', "OID":'o',  "STRING":'s', "HEX STRING":'x', "Hex-STRING":'x', "DECIMAL STRING":'d', "BITS":'b', "unsigned int64":'U', "signed int64":'I', "float":'F', "double":'D', "NULLOBJ":'n'}
+# Map between snmpwalk output and expected type by snmpset
+type_map = {
+    "INTEGER": 'i', "unsigned INTEGER": 'u', "UNSIGNED": 'u', "TIMETICKS": 't', 
+    "Timeticks": 't', "IPADDRESS": 'a', "OBJID": 'o', "OID": 'o', "STRING": 's', 
+    "HEX STRING": 'x', "Hex-STRING": 'x', "DECIMAL STRING": 'd', "BITS": 'b', 
+    "unsigned int64": 'U', "signed int64": 'I', "float": 'F', "double": 'D', 
+    "NULLOBJ": 'n'
+}
 
-#count how many OIDs are writable
-count=0
+# Count how many OIDs are writable
+count = 0
 
-
-#Iterate and parse each OID
+# Iterate and parse each OID
 for line in out.splitlines():
     try:
         oid = line.split(" = ")[0]
         type_value = line.split(" = ")[1]
-        type_ = type_map[ type_value.split(": ")[0] ] #ex: STRING: "abc"
+        type_ = type_map[type_value.split(": ")[0]]  # ex: STRING: "abc"
         value = type_value.split(": ")[1]
 
-        #for TIMETICKS extract only the numeric value
+        # Display the OID being tested if the flag is set
+        if show_tested_oids:
+            print(f"Testing OID: {oid}")
+
+        # For TIMETICKS extract only the numeric value
         if type_ == 't':
-            match = re.search('\((.+?)\)', value)
+            match = re.search(r'\((.+?)\)', value)
             if match:
                 value = match.group(1)
             else:
                 continue
-        #for HEX STRING put the value in quotes
+        # For HEX STRING put the value in quotes
         if type_ == 'x':
             value = f'"{value}"'
 
-        #Try to write the existing value once again        
+        # Try to write the existing value once again        
         cmd = f"snmpset {options_agent} {oid} {type_} {value}"
         args = shlex.split(cmd)
         if(debug):
@@ -76,11 +89,11 @@ for line in out.splitlines():
             oidtype = subprocess.run(args_get, stdout=subprocess.PIPE).stdout.decode('utf-8')
             m = re.search('=', oidtype)
             oidtype_s = oidtype[m.end():]
-            print(f"{oid} is writable - "f"{oidtype_s}")
-            count+=1
-    except:
-        pass
+            print(f"{oid} is writable - {oidtype_s.strip()}")
+            count += 1
+    except Exception as e:
+        if debug:
+            print(f"Error processing {line}: {e}")
 
-#return code is the number of found OIDs
+# Return code is the number of found OIDs
 sys.exit(count)
-


### PR DESCRIPTION
Add two optional parameters:
- BASE_OID: to specify starting OID to start walking from
- show-tested-oids will output all OIDS tested, writeable or not
